### PR TITLE
It keeps say 'Cannot find git-hooks. Did you install it?' #6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 !/node_modules/git-hooks
 /coverage
 npm-debug.log
+.idea

--- a/lib/git-hooks.js
+++ b/lib/git-hooks.js
@@ -125,14 +125,22 @@ function runHooks(hooks, args, callback) {
         return;
     }
 
-    var hook = spawn(hooks.shift(), args, {stdio: 'inherit'});
-    hook.on('close', function (code) {
-        if (code === 0) {
-            runHooks(hooks, args, callback);
-        } else {
-            callback(code);
-        }
-    });
+    var scriptFile = hooks.shift();
+    try {
+        var hook = spawn(scriptFile, args, {stdio: 'inherit'});
+        hook.on('close', function (code) {
+            if (code === 0) {
+                runHooks(hooks, args, callback);
+            } else {
+                callback(code);
+            }
+        });
+    } catch (exception) {
+        console.error('git-hooks ' + exception.code + ' unable to execute: "' + scriptFile + '"' +
+                      ' with permissions: ' + (fs.statSync(scriptFile).mode & 0777).toString(8) +
+                      ' is the file executable?');
+        callback(1);
+    }
 }
 
 /**


### PR DESCRIPTION
One of the common getting started errors is non-executable permissions on the hook script files. I have added a user friendly try/catch error message to hint at this possible problem. I have not tested this on windows, and I have not done an exhaustive list of all the reasons child_process.spawn() might throw an exception, assuming a permissions issue is the primary cause.

This however is a much less obscure error message than:
```Cannot find git-hooks. Did you install it?```

https://github.com/tarmolov/git-hooks-js/issues/6