### PR TITLE
Use a bash script for the template hook

### DIFF
--- a/bin/git-hooks
+++ b/bin/git-hooks
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
 
 var cli = require('../lib/cli');
-cli(process.argv[2]);
+cli(process.argv);

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -6,7 +6,8 @@ var options = {
     uninstall: 'Remove existing hooks in this repository and rename hooks.old back to hooks'
 };
 
-module.exports = function (command) {
+module.exports = function (argv) {
+    var command = argv[2];
     command = command && command.replace(/-/g, '');
 
     switch (command) {
@@ -16,9 +17,18 @@ module.exports = function (command) {
         case 'install':
         case 'uninstall':
             try {
-                gitHooks[command]();
+                gitHooks[command](process.cwd());
             } catch (e) {
                 console.error(e.message);
+                throw e;
+            }
+            break;
+        case 'run':
+            try {
+                gitHooks[command].apply(this, [argv[3], argv[4]]);
+            } catch (e) {
+                console.error(e.message);
+                throw e;
             }
             break;
         default:

--- a/lib/git-hooks.js
+++ b/lib/git-hooks.js
@@ -7,7 +7,7 @@ var exec = require('child_process').exec;
 
 var HOOKS_DIRNAME = 'hooks';
 var HOOKS_OLD_DIRNAME = 'hooks.old';
-var HOOKS_TEMPLATE_FILE_NAME = 'hook-template.js';
+var HOOKS_TEMPLATE_FILE_NAME = 'hook-template.sh';
 var HOOKS = [
     'applypatch-msg',
     'commit-msg',
@@ -55,17 +55,26 @@ module.exports = {
 
         var hooksPath = path.resolve(gitPath, HOOKS_DIRNAME);
         var hooksOldPath = path.resolve(gitPath, HOOKS_OLD_DIRNAME);
+        var hooksPathExists = fsHelpers.exists(hooksPath);
+        var hooksOldPathExists = fsHelpers.exists(hooksOldPath);
 
-        if (fsHelpers.exists(hooksOldPath)) {
+        // TODO This is not particularly accurate.
+        // What if something else uses the same `.old` suffix?
+        console.log('DEBUG', hooksPath, hooksPathExists, hooksOldPath, hooksOldPathExists);
+        if (hooksOldPathExists) {
             throw new Error('git-hooks already installed');
         }
 
-        if (fsHelpers.exists(hooksPath)) {
+        if (hooksPathExists) {
+            if (hooksOldPathExists) {
+                fsHelpers.removeDir(hooksOldPath);
+            }
             fs.renameSync(hooksPath, hooksOldPath);
         }
 
         var hookTemplate = fs.readFileSync(__dirname + '/' + HOOKS_TEMPLATE_FILE_NAME);
-        var pathToGitHooks = path.relative(hooksPath, __dirname);
+        // use an absolute path, in case of symlinks
+        var pathToGitHooks = path.resolve(__dirname);
         // Fix non-POSIX (Windows) separators
         pathToGitHooks = pathToGitHooks.replace(new RegExp(path.sep.replace(/\\/g, '\\$&'), 'g'), '/');
         var hook = util.format(hookTemplate.toString(), pathToGitHooks);
@@ -115,9 +124,12 @@ module.exports = {
      *
      * @param {String} filename Path to git hook.
      * @param {String} [arg] Git hook argument.
-     * @param {Function} callback
+     * @param {Function} callback, defaults to exit with return code.
      */
     run: function (filename, arg, callback) {
+        if (typeof callback !== 'function') {
+            callback = function (code) { process.exit(code); };
+        }
         var hookName = path.basename(filename);
         var hooksDirname = path.resolve(path.dirname(filename), '../../.githooks', hookName);
 

--- a/lib/hook-template.sh
+++ b/lib/hook-template.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+
+NODE=$(type -P node)
+if [ -z "$NODE" ]; then
+  # Bootstrap nvm environment, for GUI tools.
+  # This assumes nvm was installed per-user in `~/.nvm`.
+  if [ -z "$NVM_DIR" ]; then
+    export NVM_DIR="$HOME/.nvm"
+  fi
+  NVM_SH="$NVM_DIR/nvm.sh"
+  if [ -x "$NVM_SH" ]; then
+    source "$NVM_SH"
+  else
+    echo "skipping git-hooks: nvm.sh at $NVM_SH is missing, unreadable, or not executable!" >&2
+    exit 0
+  fi
+fi
+
+CMD='%s/../bin/git-hooks'
+if [ -x "$CMD" ]; then
+  "$CMD" --run $0 $2
+else
+  echo "skipping git-hooks: missing node module $CMD" >&2
+  exit 0
+fi
+
+# end


### PR DESCRIPTION
This allows use with GUI tools such as IDEs, which sometimes can't find the `node` command in the environment `PATH`. This implementation assumes nvm, and expects node to be available through `$HOME/.nvm`.

This approach might not suit every environment. It might make sense to have an install-time switch between node-based hooks and bash-based hooks, maybe using environment variables.