### PR TITLE
Allow multiple CLI arguments

### DIFF
--- a/lib/git-hooks.js
+++ b/lib/git-hooks.js
@@ -113,11 +113,11 @@ module.exports = {
     /**
      * Runs a git hook.
      *
-     * @param {String} filename Path to git hook.
-     * @param {String} [arg] Git hook argument.
+     * @param {String}   filename Path to git hook.
+     * @param {String[]} [args]   Git hook arguments.
      * @param {Function} callback
      */
-    run: function (filename, arg, callback) {
+    run: function (filename, args, callback) {
         var hookName = path.basename(filename);
         var hooksDirname = path.resolve(path.dirname(filename), '../../.githooks', hookName);
 
@@ -127,7 +127,7 @@ module.exports = {
                 return path.resolve(hooksDirname, hookName);
             });
             excludeIgnoredPaths(hooks, function (filteredHooks) {
-                runHooks(filteredHooks, [arg], callback);
+                runHooks(filteredHooks, args, callback);
             });
         } else {
             callback(0);

--- a/lib/hook-template.js
+++ b/lib/hook-template.js
@@ -8,7 +8,7 @@ try {
      * www
      *     node_modules
      */
-    require('%s/git-hooks').run(__filename, process.argv[2], function (code, error) {
+    require('%s/git-hooks').run(__filename, process.argv.slice(2), function (code, error) {
         if (error) {
             console.error('[GIT-HOOKS ERROR] ' + error.message);
         }

--- a/tests/run.test.js
+++ b/tests/run.test.js
@@ -26,7 +26,7 @@ describe('git-hook runner', function () {
     });
 
     it('should works without hooks', function (done) {
-        gitHooks.run(PRECOMMIT_HOOK_PATH, null, function (code) {
+        gitHooks.run(PRECOMMIT_HOOK_PATH, [], function (code) {
             code.should.equal(0);
             done();
         });
@@ -44,7 +44,7 @@ describe('git-hook runner', function () {
             });
 
             it('should return an error', function (done) {
-                gitHooks.run(PRECOMMIT_HOOK_PATH, null, function (code, error) {
+                gitHooks.run(PRECOMMIT_HOOK_PATH, [], function (code, error) {
                     code.should.equal(1);
                     error.should.be.ok;
                     done();
@@ -62,7 +62,7 @@ describe('git-hook runner', function () {
             });
 
             it('should run it one by one', function (done) {
-                gitHooks.run(PRECOMMIT_HOOK_PATH, null, function (code) {
+                gitHooks.run(PRECOMMIT_HOOK_PATH, [], function (code) {
                     code.should.equal(0);
                     hooks.forEach(function (name) {
                         var logFile = SANDBOX_PATH + name + '.log';
@@ -73,16 +73,23 @@ describe('git-hook runner', function () {
             });
         });
 
-        describe('and works without errors', function () {
+        describe('and work without errors', function () {
             var logFile = SANDBOX_PATH + 'hello.log';
             beforeEach(function () {
-                createHook(PROJECT_PRECOMMIT_HOOK + 'hello', 'echo Hello, world! > ' + logFile);
+                createHook(PROJECT_PRECOMMIT_HOOK + 'hello', 'echo "Hello, world! ${@:1}" > ' + logFile);
+            });
+
+            it('should pass all arguments to them', function (done) {
+                gitHooks.run(PRECOMMIT_HOOK_PATH, ['I', 'am', 'working', 'properly!'], function () {
+                    fs.readFileSync(logFile).toString().should.equal('Hello, world! I am working properly!\n');
+                    done();
+                });
             });
 
             it('should run a hook with success status', function (done) {
-                gitHooks.run(PRECOMMIT_HOOK_PATH, null, function (code) {
+                gitHooks.run(PRECOMMIT_HOOK_PATH, [], function (code) {
                     code.should.equal(0);
-                    fs.readFileSync(logFile).toString().should.equal('Hello, world!\n');
+                    fs.readFileSync(logFile).toString().should.equal('Hello, world! \n');
                     done();
                 });
             });
@@ -94,7 +101,7 @@ describe('git-hook runner', function () {
             });
 
             it('should run a hook and return error', function (done) {
-                gitHooks.run(PRECOMMIT_HOOK_PATH, null, function (code) {
+                gitHooks.run(PRECOMMIT_HOOK_PATH, [], function (code) {
                     code.should.equal(255);
                     done();
                 });
@@ -112,7 +119,7 @@ describe('git-hook runner', function () {
             });
 
             it('should ignore file with wrong permissions in hooks directory', function (done) {
-                gitHooks.run(PRECOMMIT_HOOK_PATH, null, function (code) {
+                gitHooks.run(PRECOMMIT_HOOK_PATH, [], function (code) {
                     code.should.equal(0);
                     done();
                 });


### PR DESCRIPTION
Git hooks can be passed multiple arguments when they're called
(e.g., the pre-push hook gets passed the name and location of
the destination remote). The hooks were only being passed the 2nd
argument, so this commit fixes that.