### PR TITLE
Allow execution on Windows

### DIFF
--- a/lib/git-hooks.js
+++ b/lib/git-hooks.js
@@ -167,7 +167,8 @@ function runHooks(hooks, args, callback) {
  * @returns {Boolean}
  */
 function isExecutable(stats) {
-    return (stats.mode & 1) ||
+    return process.platform == 'win32' || //don't check for executable bit on windows, it doesn't exist
+        (stats.mode & 1) ||
         (stats.mode & 8) && process.getgid && stats.gid === process.getgid() ||
         (stats.mode & 64) && process.getuid && stats.uid === process.getuid();
 }
@@ -185,7 +186,36 @@ function spawnHook(hookName, args) {
     if (!isHookExecutable) {
         throw new Error('Cannot execute hook: ' + hookName + '. Please check file permissions.');
     }
-    return spawn(hookName, args, {stdio: 'inherit'});
+    var command;
+    if(process.platform != 'win32') {
+        command = hookName;
+    } else {
+        //We're on Windows.
+        // Windows can only run .cmd and .bat scripts (besides executables)
+        // so attempting to launch a script directly won't work.
+        // Thankfully, git is installed and comes with sh, so we can use that.
+
+        //sh isn't on the path for a default git install, so we need to determine
+        // where it might be installed
+        var x64ProgramFiles = 'C:\\Program Files';
+        var x86ProgramFiles = 'C:\\Program Files (x86)';
+        var shRelativeToProgramFiles = '\\Git\\usr\\bin\\sh.exe';
+
+        try {
+            fs.statSync(x64ProgramFiles + shRelativeToProgramFiles);
+            command = x64ProgramFiles + shRelativeToProgramFiles;
+        } catch(e) {}
+        try {
+            fs.statSync(x86ProgramFiles + shRelativeToProgramFiles);
+            command = x86ProgramFiles + shRelativeToProgramFiles;
+        } catch(e) {}
+
+        //command should now be set to whichever git path exists, if any
+
+        args.unshift(hookName); //add the script as the first argument
+    }
+
+    return spawn(command, args, {stdio: 'inherit'});
 }
 
 /**

--- a/lib/git-hooks.js
+++ b/lib/git-hooks.js
@@ -167,7 +167,7 @@ function runHooks(hooks, args, callback) {
  * @returns {Boolean}
  */
 function isExecutable(stats) {
-    return process.platform == 'win32' || //don't check for executable bit on windows, it doesn't exist
+    return process.platform === 'win32' || // don't check for executable bit on windows, it doesn't exist
         (stats.mode & 1) ||
         (stats.mode & 8) && process.getgid && stats.gid === process.getgid() ||
         (stats.mode & 64) && process.getuid && stats.uid === process.getuid();
@@ -187,16 +187,16 @@ function spawnHook(hookName, args) {
         throw new Error('Cannot execute hook: ' + hookName + '. Please check file permissions.');
     }
     var command;
-    if(process.platform != 'win32') {
+    if (process.platform !== 'win32') {
         command = hookName;
     } else {
-        //We're on Windows.
-        // Windows can only run .cmd and .bat scripts (besides executables)
-        // so attempting to launch a script directly won't work.
-        // Thankfully, git is installed and comes with sh, so we can use that.
-
-        //sh isn't on the path for a default git install, so we need to determine
-        // where it might be installed
+        /* We're on Windows.
+           Windows can only run .cmd and .bat scripts (besides executables)
+           so attempting to launch a script directly won't work.
+           Thankfully, git is installed and comes with sh, so we can use that.
+           sh isn't on the path for a default git install, so we need to determine
+           where it might be installed
+        */
         var x64ProgramFiles = 'C:\\Program Files';
         var x86ProgramFiles = 'C:\\Program Files (x86)';
         var shRelativeToProgramFiles = '\\Git\\usr\\bin\\sh.exe';
@@ -204,15 +204,15 @@ function spawnHook(hookName, args) {
         try {
             fs.statSync(x64ProgramFiles + shRelativeToProgramFiles);
             command = x64ProgramFiles + shRelativeToProgramFiles;
-        } catch(e) {}
+        } catch (e) {}
         try {
             fs.statSync(x86ProgramFiles + shRelativeToProgramFiles);
             command = x86ProgramFiles + shRelativeToProgramFiles;
-        } catch(e) {}
+        } catch (e) {}
 
-        //command should now be set to whichever git path exists, if any
+        // command should now be set to whichever git path exists, if any
 
-        args.unshift(hookName); //add the script as the first argument
+        args.unshift(hookName); // add the script as the first argument
     }
 
     return spawn(command, args, {stdio: 'inherit'});


### PR DESCRIPTION
There are 2 issues blocking windows execution: verifying execution bit and launching Unix-style scripts. This PR resolves both. 
