### PR TITLE
Use absolute path to git-hooks lib instead of relative (#49)

### DIFF
--- a/lib/git-hooks.js
+++ b/lib/git-hooks.js
@@ -51,7 +51,7 @@ module.exports = {
         }
 
         var hookTemplate = fs.readFileSync(__dirname + '/' + HOOKS_TEMPLATE_FILE_NAME);
-        var pathToGitHooks = path.relative(hooksPath, __dirname);
+        var pathToGitHooks = __dirname;
         // Fix non-POSIX (Windows) separators
         pathToGitHooks = pathToGitHooks.replace(new RegExp(path.sep.replace(/\\/g, '\\$&'), 'g'), '/');
         var hook = util.format(hookTemplate.toString(), pathToGitHooks);


### PR DESCRIPTION
fix for https://github.com/tarmolov/git-hooks-js/issues/49

should not affect projects that currently use `git-hooks`, they will continue include the library from relative path, new installations - will start use absolute path.