### PR TITLE
Use existence of backup as marker for installation

### DIFF
--- a/lib/git-hooks.js
+++ b/lib/git-hooks.js
@@ -47,9 +47,11 @@ module.exports = {
             throw new Error('git-hooks already installed');
         }
 
-        if (fsHelpers.exists(hooksPath)) {
-            fs.renameSync(hooksPath, hooksOldPath);
+        if (!fsHelpers.exists(hooksPath)) {
+            // Standard hooks folder has been removed - make an empty placeholder one
+            fsHelpers.makeDir(hooksPath);
         }
+        fs.renameSync(hooksPath, hooksOldPath);
 
         var hookTemplate = fs.readFileSync(__dirname + '/' + HOOKS_TEMPLATE_FILE_NAME);
         var pathToGitHooks = __dirname;
@@ -86,13 +88,11 @@ module.exports = {
         var hooksPath = path.resolve(gitPath, HOOKS_DIRNAME);
         var hooksOldPath = path.resolve(gitPath, HOOKS_OLD_DIRNAME);
 
-        if (!fsHelpers.exists(hooksPath)) {
-            throw new Error('git-hooks is not installed');
-        }
-
         if (fsHelpers.exists(hooksOldPath)) {
             fsHelpers.removeDir(hooksPath);
             fs.renameSync(hooksOldPath, hooksPath);
+        } else {
+            throw new Error('git-hooks is not installed');
         }
     },
 

--- a/tests/uninstall.test.js
+++ b/tests/uninstall.test.js
@@ -1,15 +1,17 @@
 require('chai').should();
+var execSync = require('child_process').execSync;
 var gitHooks = require('../lib/git-hooks');
 var fsHelpers = require('../lib/fs-helpers');
 
-var SANDBOX_PATH = __dirname + '/tmp-sandbox/';
+var SANDBOX_PATH = '/tmp/tmp-sandbox/';
 var GIT_ROOT = SANDBOX_PATH + '.git/';
 var GIT_HOOKS = GIT_ROOT + 'hooks';
 var GIT_HOOKS_OLD = GIT_ROOT + 'hooks.old';
 
 describe('--uninstall', function () {
     beforeEach(function () {
-        fsHelpers.makeDir(GIT_ROOT);
+        fsHelpers.makeDir(SANDBOX_PATH);
+        execSync('git init', {cwd: SANDBOX_PATH});
     });
 
     afterEach(function () {
@@ -39,19 +41,18 @@ describe('--uninstall', function () {
     });
 
     describe('when backup is absent', function () {
-        beforeEach(function () {
-            fsHelpers.makeDir(GIT_HOOKS);
-        });
 
         it('should not remove hooks directory', function () {
-            gitHooks.uninstall(SANDBOX_PATH);
+            var fn = function () {
+                gitHooks.uninstall(SANDBOX_PATH);
+            };
+            fn.should.throw(Error);
             fsHelpers.exists(GIT_HOOKS).should.be.true;
         });
     });
 
     describe('when backup exists', function () {
         beforeEach(function () {
-            fsHelpers.makeDir(GIT_HOOKS);
             fsHelpers.makeDir(GIT_HOOKS_OLD);
         });
 


### PR DESCRIPTION
* Always make a backup when installing
* Always check for backup when uninstalling - use presence of backup to indicate if we are installed.

Prior to this PR, on uninstallation, you would only get a `git-hooks is not installed` error if there was no .git/hooks folder, but installation would never remove that folder. It would replace it, if there was a backup to replace it with, or leave it if there was not.

In practise having no hooks folder would never happen as git will automatically create a hooks folder with samples by default. You have to take steps to remove it.

After this PR, install will always make a backup of the current hooks folder, or make a placeholder if it didn't exist. It will use the presence of this backup to detect if it has been installed, and uninstall correctly, giving an error whenever it is not installed, even if the user already had manually added git hooks for the project.

I've been working on a solution to https://github.com/tarmolov/git-hooks-js/issues/48, but couldn't get new tests to pass until I sorted out this anomaly.