### PR TITLE
Remove git-hooks bin symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-/node_modules/*
-/node_modules/.bin/*
-!/node_modules/.bin/git-hooks
+/node_modules
 /coverage
 npm-debug.log

--- a/node_modules/.bin/git-hooks
+++ b/node_modules/.bin/git-hooks
@@ -1,1 +1,0 @@
-../../bin/git-hooks


### PR DESCRIPTION
It's not been needed since ead2287