### PR TITLE
Move to eslint instead of JSCS and JSHint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+    extends: 'loris/es5',
+    root: true,
+    env: {
+        node: true
+    }
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "contributors": [
     "Alexander Tarmolov <tarmolov@gmail.com> (http://tarmolov.ru/)",
     "Denis Khananein <i@zloylos.me> (http://zloy.me/)",
-    "Ikonnikov Konstantin"
+    "Ikonnikov Konstantin",
+    "Robert (Jamie) Munro <jamie@diffblue.com>"
   ],
   "keywords": [
     "git",
@@ -38,7 +39,7 @@
   "scripts": {
     "postinstall": "./bin/git-hooks --install",
     "preuninstall": "./bin/git-hooks --uninstall",
-    "test": "jscs . && jshint . && mocha --reporter spec --recursive tests",
+    "test": "eslint lib tests && mocha --reporter spec --recursive tests",
     "coverage": "istanbul cover _mocha --recursive tests"
   },
   "main": "lib/git-hooks",
@@ -49,9 +50,9 @@
   ],
   "devDependencies": {
     "chai": "4.1.2",
+    "eslint": "4.19.1",
+    "eslint-config-loris": "9.1.0",
     "istanbul": "0.4.5",
-    "jscs": "2.11.0",
-    "jshint": "2.9.5",
     "mocha": "5.1.1"
   },
   "license": "MIT"


### PR DESCRIPTION
This follows on from a reqest in https://github.com/tarmolov/git-hooks-js/pull/55, but I'm not including it in that PR as there is too much work for me to do straight away, and I'm not sure if the right solution is to change the config to match the code style or change the code style to match the config.