### PR TITLE
Use universal she-bang for Debian-based systems

### DIFF
--- a/lib/hook-template.js
+++ b/lib/hook-template.js
@@ -1,4 +1,5 @@
-#!/usr/bin/env node
+#!/bin/sh
+':' //; exec "$(command -v nodejs || command -v node)" "$0" "$@"
 
 try {
     /**


### PR DESCRIPTION
On some versions of Debian (and thus, Ubuntu and friends), `node` is installed as `nodejs`.  This means that the default node shebang does not work, since there is no `node` binary.  

The fix here is to use the bourne shell shebang and then invoke the remainder of the script as node or nodejs, depending on what's installed on the system.  This is based off of [this Unix StackExchange answer](https://unix.stackexchange.com/a/65295).

Because this happens in the shebang, it is outside of the `try / catch`, and therefore fails any git operations, regardless of if there are hooks installed or not.