### PR TITLE
Use relative path to git-hooks in installed hooks scripts

### DIFF
--- a/lib/git-hooks.js
+++ b/lib/git-hooks.js
@@ -57,6 +57,8 @@ module.exports = {
         var pathToGitHooks = __dirname;
         // Fix non-POSIX (Windows) separators
         pathToGitHooks = pathToGitHooks.replace(new RegExp(path.sep.replace(/\\/g, '\\$&'), 'g'), '/');
+        // Then make the path relative
+        pathToGitHooks = path.relative(hooksPath, pathToGitHooks);
         var hook = util.format(hookTemplate.toString(), pathToGitHooks);
 
         fsHelpers.makeDir(hooksPath);


### PR DESCRIPTION
Before this patch, installing git-hooks would use absolute paths to
require `node_modules/git-hooks/lib/git-hooks`. This works most of
the time, but there are instances in which it does not. For example:

I do development on a host machine, but yarn install runs inside a
Docker container. In this case, the absolute path to `node_modules`
is different in the two environments. This means for the git-hooks
module to work as intended, I am only able to run Git commands from
inside of the container. I typically run Git commands from the host
machine, so this doesn't work for me.

More importantly, though, I see no reason to force everybody working
on my project to use Git in one environment or the other.

After this patch, installed git-hooks use relative paths to require
`node_modules/git-hooks/lib/git-hooks`.